### PR TITLE
Add JSON config and workflow for Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
-          echo "matrix=$(jq -c 'to_entries | map({image: .key} + .value)' versions.json)" >> $GITHUB_OUTPUT
+          echo "matrix=$(jq -c 'to_entries | map({tag: .key} + .value)' versions.json)" >> $GITHUB_OUTPUT
 
   build:
     needs: prepare
@@ -35,12 +35,14 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build image
         run: |
+          IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/mindformers:${{ matrix.config.tag }}
           docker build -f Dockerfile.base \
             --build-arg PYTHON_VERSION=${{ matrix.config.PYTHON_VERSION }} \
             --build-arg CANN_TOOLKIT_URL=${{ matrix.config.CANN_TOOLKIT_URL }} \
             --build-arg CANN_KERNELS_URL=${{ matrix.config.CANN_KERNELS_URL }} \
             --build-arg MS_WHL_URL=${{ matrix.config.MS_WHL_URL }} \
             --build-arg MINDFORMERS_GIT_REF=${{ matrix.config.MINDFORMERS_GIT_REF }} \
-            -t ${{ matrix.config.image }} .
+            -t $IMAGE .
+          echo "image=$IMAGE" >> $GITHUB_ENV
       - name: Push image
-        run: docker push ${{ matrix.config.image }}
+        run: docker push ${{ env.image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build and Push Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ work ]
+    paths:
+      - 'versions.json'
+      - '.github/workflows/build.yml'
+      - 'Dockerfile.base'
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        run: |
+          echo "matrix=$(jq -c 'to_entries | map({image: .key} + .value)' versions.json)" >> $GITHUB_OUTPUT
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        run: |
+          docker build -f Dockerfile.base \
+            --build-arg PYTHON_VERSION=${{ matrix.config.PYTHON_VERSION }} \
+            --build-arg CANN_TOOLKIT_URL=${{ matrix.config.CANN_TOOLKIT_URL }} \
+            --build-arg CANN_KERNELS_URL=${{ matrix.config.CANN_KERNELS_URL }} \
+            --build-arg MS_WHL_URL=${{ matrix.config.MS_WHL_URL }} \
+            --build-arg MINDFORMERS_GIT_REF=${{ matrix.config.MINDFORMERS_GIT_REF }} \
+            -t ${{ matrix.config.image }} .
+      - name: Push image
+        run: docker push ${{ matrix.config.image }}

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,9 @@
+{
+  "mindformers-r1.6.0:ms2.7.0-rc1_cann8.2.RC1_py3.11": {
+    "PYTHON_VERSION": "3.11.4",
+    "CANN_TOOLKIT_URL": "https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-toolkit_8.2.RC1_linux-aarch64.run",
+    "CANN_KERNELS_URL": "https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-kernels-910b_8.2.RC1_linux-aarch64.run",
+    "MS_WHL_URL": "https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.7.0rc1/MindSpore/unified/aarch64/mindspore-2.7.0rc1-cp311-cp311-linux_aarch64.whl",
+    "MINDFORMERS_GIT_REF": "r1.6.0"
+  }
+}

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-  "mindformers-r1.6.0:ms2.7.0-rc1_cann8.2.RC1_py3.11": {
+  "r1.6.0_ms2.7.0-rc1_cann8.2.RC1_py3.11": {
     "PYTHON_VERSION": "3.11.4",
     "CANN_TOOLKIT_URL": "https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-toolkit_8.2.RC1_linux-aarch64.run",
     "CANN_KERNELS_URL": "https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-kernels-910b_8.2.RC1_linux-aarch64.run",


### PR DESCRIPTION
## Summary
- add `versions.json` to define build args for MindFormers images
- add GitHub Actions workflow to build and push images using the JSON matrix

## Testing
- `python -m json.tool versions.json`
- `python - <<'PY'
import yaml,sys
print('YAML loaded successfully')
print(yaml.safe_load(open('.github/workflows/build.yml'))['name'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_688d88fbf460832db247a91f0e6c38f8