### PR TITLE
Add JSON config and workflow for Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build and Push Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Comma-separated image tags to build'
+        required: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set-matrix
+        run: |
+          TAGS="${{ github.event.inputs.tags }}"
+          if [ -n "$TAGS" ]; then
+            matrix=$(jq --arg tags "$TAGS" -c '
+              ($tags | split(",") | map(gsub("^\\s+|\\s+$"; ""))) as $sel |
+              to_entries | map(select(.key as $k | $sel | index($k)) | {tag: .key} + .value)
+            ' versions.json)
+          else
+            matrix=$(jq -c 'to_entries | map({tag: .key} + .value)' versions.json)
+          fi
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push image
+        run: |
+          IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/mindformers:${{ matrix.config.tag }}
+          docker buildx build --platform linux/arm64 \
+            -f Dockerfile.base \
+            --build-arg PYTHON_VERSION=${{ matrix.config.PYTHON_VERSION }} \
+            --build-arg CANN_TOOLKIT_URL=${{ matrix.config.CANN_TOOLKIT_URL }} \
+            --build-arg CANN_KERNELS_URL=${{ matrix.config.CANN_KERNELS_URL }} \
+            --build-arg MS_WHL_URL=${{ matrix.config.MS_WHL_URL }} \
+            --build-arg MINDFORMERS_GIT_REF=${{ matrix.config.MINDFORMERS_GIT_REF }} \
+            -t $IMAGE \
+            --push .

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ git clone https://gitee.com/jimmyisme/mindformers-dockerfile.git
 cd mindformers-dockerfile
 docker build --network host -t mindformers-r1.5.0-mindspore-2.6.0.rc1-py3.11:20250609 --build-arg TARGETPLATFORM=linux/arm64 -f Dockerfile.r1.5.0 .
 ```
+
+## GitHub Actions
+
+仓库提供了一个手动触发的工作流，用于根据 `versions.json` 构建并推送镜像。
+在 GitHub 页面中执行 **Run workflow** 并填写 `tags` 输入，输入值为 `versions.json` 中对应的镜像标签，多个标签使用逗号分隔，例如：
+
+```
+r1.6.0_ms2.7.0-rc1_cann8.2.RC1_py3.11
+```
+
+工作流只会构建在 `tags` 中指定的镜像，并使用 QEMU 与 Buildx 生成 `linux/arm64` 架构的镜像。

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,9 @@
+{
+  "r1.6.0_ms2.7.0-rc1_cann8.2.RC1_py3.11": {
+    "PYTHON_VERSION": "3.11.4",
+    "CANN_TOOLKIT_URL": "https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-toolkit_8.2.RC1_linux-aarch64.run",
+    "CANN_KERNELS_URL": "https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%208.2.RC1/Ascend-cann-kernels-910b_8.2.RC1_linux-aarch64.run",
+    "MS_WHL_URL": "https://ms-release.obs.cn-north-4.myhuaweicloud.com/2.7.0rc1/MindSpore/unified/aarch64/mindspore-2.7.0rc1-cp311-cp311-linux_aarch64.whl",
+    "MINDFORMERS_GIT_REF": "r1.6.0"
+  }
+}


### PR DESCRIPTION
## Summary
- rework `versions.json` so keys become image tags in the `<mf_version>_ms<ms_version>_cann<cann_version>_py<pyversion>` format
- update GitHub Actions workflow to push `mindformers` images tagged from the JSON matrix
- allow manual `workflow_dispatch` input to select which tags to build and push
- build and push `linux/arm64` images with Docker Buildx

## Testing
- `python -m json.tool versions.json`
- `pip install pyyaml`
- `python - <<'PY'
import yaml,sys
print('YAML loaded successfully')
print(yaml.safe_load(open('.github/workflows/build.yml'))['name'])
PY`
- `jq -c 'to_entries | map({tag: .key} + .value)' versions.json`


------
https://chatgpt.com/codex/tasks/task_e_688d88fbf460832db247a91f0e6c38f8