### PR TITLE
chore: use arm64 hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,7 @@ on:
 
 jobs:
   prepare:
-    runs-on:
-      group: ubuntu-latest
-      architecture: arm64
+    runs-on: ubuntu-24.04-arm
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -34,9 +32,7 @@ jobs:
 
   build:
     needs: prepare
-    runs-on:
-      group: ubuntu-latest
-      architecture: arm64
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         config: ${{ fromJSON(needs.prepare.outputs.matrix) }}


### PR DESCRIPTION
## Summary
- use `ubuntu-24.04-arm` GitHub Actions runner for arm64 builds

## Testing
- `yamllint .github/workflows/build.yml` *(fails: missing document start, bracket spacing, line too long)*

------
https://chatgpt.com/codex/tasks/task_e_688dd5d43a34832dbbea88f1975ff07c